### PR TITLE
added minimal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI testing
+
+on:
+    pull_request:
+      branches:
+        - dev
+        - main
+    push:
+      branches:
+        - main
+
+jobs:
+    testing:
+      name: CI (Python=${{ matrix.python-version }}, OS=${{ matrix.os }})
+      runs-on: ${{ matrix.os }}
+      defaults:
+        run:
+          shell: bash -el {0}
+      strategy:
+        matrix:
+          os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+          python-version: ["3.11"]
+
+          include:
+            - python-version: "3.8"
+              os: "ubuntu-latest"
+            - python-version: "3.9"
+              os: "ubuntu-latest"
+            - python-version: "3.10"
+              os: "ubuntu-latest"
+      steps:
+        - name: checkout actions
+          uses: actions/checkout@v4
+        - uses: conda-incubator/setup-miniconda@v3
+          with:
+            auto-update-conda: true
+            python-version: ${{ matrix.python-version }}
+            channels: conda-forge
+
+        - name: install dependencies
+          run: conda install -c conda-forge freecad -y
+
+        - name: install package
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install .
+            python -c 'import GEOUNED'
+            python -c 'from GEOReverse import reverse'
+            python -m pip install .[tests]
+
+        - name: testing GEOUNED functionality
+          if: ${{ matrix.os == 'ubuntu-latest'}}
+          run: python -m pytest -s -v --freecad-cmd=python tests/test_convert.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
 
         - name: testing GEOUNED functionality
           if: ${{ matrix.os == 'ubuntu-latest'}}
-          run: python -m pytest -s -v --freecad-cmd=python tests/test_convert.py
+          run: python -m pytest -v tests/test_convert.py

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/source/_autosummary/*
 docs/jupyter_execute
 .pytest_cache/**
 build/
+tests_outputs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,8 @@ classifiers = [
 Homepage = "https://github.com/GEOUNED-code"
 Repository = "https://github.com/GEOUNED-code/GEOUNED"
 Documentation = "https://github.com/GEOUNED-code/GEOUNED/docs"
+
+[project.optional-dependencies]
+tests = [
+    "pytest",
+]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+
+import GEOUNED
+
+path_to_cad = Path("testing/inputSTEP")
+step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step"))
+
+
+@pytest.mark.parametrize("input_step_file", step_files[1:4])
+def test_conversion(input_step_file):
+    """Test that step files can be converted to openmc and mcnp files"""
+
+    # sets up an output folder for the results
+    output_dir = Path("tests_outputs") / input_step_file.with_suffix("")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_filename_stem = output_dir / input_step_file.stem
+
+    # creates the config file contents
+    template = (
+        "[Files]\n"
+        "title = 'Input Test'\n"
+        f"stepFile = {input_step_file.resolve()}\n"
+        f"geometryName = {output_filename_stem.resolve()}\n"
+        "outFormat = ('mcnp', 'openMC_XML')\n"
+        "[Parameters]\n"
+        "compSolids = False\n"
+        "volCARD = False\n"
+        "volSDEF = True\n"
+        "voidGen = True\n"
+        "dummyMat = True\n"
+        "minVoidSize = 100\n"
+        "cellSummaryFile = False\n"
+        "cellCommentFile = False\n"
+        "debug = False\n"
+        "simplify = full\n"
+        "[Options]\n"
+        "forceCylinder = False\n"
+        "splitTolerance = 0\n"
+        "newSplitPlane = True\n"
+        "nPlaneReverse = 0\n"
+    )
+
+    with open(output_dir / "config.ini", mode="w") as file:
+        file.write(template)
+
+    # deletes the output openmc and mcnp output files if it already exists
+    output_filename_stem.with_suffix(".mcnp").unlink(missing_ok=True)
+    output_filename_stem.with_suffix(".xml").unlink(missing_ok=True)
+
+    inifile = f"{output_dir/'config.ini'}"
+    GEO = GEOUNED.GEOUNED(inifile)
+    GEO.SetOptions()
+    GEO.outFormat = ("mcnp", "openMC_XML")
+    GEO.Start()
+
+    assert output_filename_stem.with_suffix(".mcnp").exists()
+    assert output_filename_stem.with_suffix(".xml").exists()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -8,7 +8,7 @@ path_to_cad = Path("testing/inputSTEP")
 step_files = list(path_to_cad.rglob("*.stp")) + list(path_to_cad.rglob("*.step"))
 
 
-@pytest.mark.parametrize("input_step_file", step_files[1:4])
+@pytest.mark.parametrize("input_step_file", step_files)
 def test_conversion(input_step_file):
     """Test that step files can be converted to openmc and mcnp files"""
 


### PR DESCRIPTION
This PR adds minimal CI that installs the GEOUNED package and FreeCAD (using Conda). Then it converts all 52 the step files found in the testing/inputSTEPS folder and checks that an openmc and mcnp output file exist.

A combination of Python versions and operating systems are tested, this can be changed but for now I've gone with:

|             | Linux (Ubuntu) | Windows | Mac OS |
|-------------|----------------|---------|--------|
| Python 3.8  | tested         |         |        |
| Python 3.9  | tested         |         |        |
| Python 3.10 | tested         |         |        |
| Python 3.11 | tested         | tested  | tested |

If this PR is successful I can follow it up with some additional testing that checks the volumes of the resulting solids and checks that the resulting openmc files work with particle transport. 